### PR TITLE
Fixed error when compiling on linux. 

### DIFF
--- a/src/app/init.go
+++ b/src/app/init.go
@@ -11,7 +11,6 @@ import (
 
 var osName string
 
-//go:embed resources_enc
 var resources embed.FS
 
 var stdin *bufio.Reader


### PR DESCRIPTION
Perhaps comment is out of block-scope?
Running with the commented code returns
`src/app/init.go:14:12: pattern resources_enc: no matching files found`
Deleting the line compiles the code fine.